### PR TITLE
Add control flow

### DIFF
--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -99,6 +99,14 @@ class ActiveOperation::Base
     halted? || succeeded?
   end
 
+  def when_succeeded(&callback)
+    callback.call(output) if succeeded?
+  end
+
+  def when_halted(&callback)
+    callback.call(output) if halted?
+  end
+
   protected
 
   def execute

--- a/spec/active_operation/callbacks_spec.rb
+++ b/spec/active_operation/callbacks_spec.rb
@@ -5,7 +5,7 @@ describe ActiveOperation::Base do
     let(:states) { [:before, :around, :around_after, :execute, :after] }
     let(:error_monitor) { spy("Error monitor") }
     let(:succeeded_monitor) { spy("Succeeded Monitor") }
-    let(:halted_monitor) { spy("Succeeded Monitor") }
+    let(:halted_monitor) { spy("Halted Monitor") }
 
     subject :operation do
       states = self.states

--- a/spec/active_operation/control_flow_spec.rb
+++ b/spec/active_operation/control_flow_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe ActiveOperation::Base do
+  context "control flow" do
+    subject(:operation) do
+      Class.new(described_class) do
+        property :desired_outcome, accepts: [:succeeded, :halted], required: true
+
+        def execute
+          case desired_outcome
+          when :succeeded
+            succeed :succeeded
+          when :halted
+            halt :halted
+          end
+        end
+      end
+    end
+
+    it "should run #when_succeeded callbacks if the operation succeeded" do
+      operation_instance = operation.run(desired_outcome: :succeeded)
+      expect { operation_instance.when_succeeded { throw :succeeded } }.to throw_symbol(:succeeded)
+    end
+
+    it "should invoke #when_succeeded callbacks with the output" do
+      operation_instance = operation.run(desired_outcome: :succeeded)
+      operation_instance.when_succeeded do |output|
+        expect(output).to be(:succeeded)
+      end
+    end
+
+    it "should run #when_halted callbacks if the operation halted" do
+      operation_instance = operation.run(desired_outcome: :halted)
+      expect { operation_instance.when_halted { throw :halted } }.to throw_symbol(:halted)
+    end
+
+    it "should invoke #when_halted callbacks with the output" do
+      operation_instance = operation.run(desired_outcome: :halted)
+      operation_instance.when_halted do |output|
+        expect(output).to be(:halted)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `ActiveOperation::Base#when_succeeded` and `ActiveOperation::Base#when_halted` for running code after the execution of an operation depending on its outcome.
