### PR TITLE
ActiveOperation Execution API

### DIFF
--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -14,12 +14,12 @@ class ActiveOperation::Base
   define_callbacks :halted
 
   class << self
-    def perform(*args)
-      new(*args).perform
+    def call(*args)
+      new(*args).call
     end
 
-    def run(*args)
-      new(*args).run
+    def output(*args)
+      new(*args).output
     end
 
     protected
@@ -62,11 +62,11 @@ class ActiveOperation::Base
     end
   end
 
-  def run
+  def call
     run_callbacks :execute do
       catch(:interrupt) do
         next if completed?
-        self.output = execute
+        @output = execute
         self.state = :succeeded
       end
     end
@@ -82,9 +82,9 @@ class ActiveOperation::Base
     raise
   end
 
-  def perform
-    run
-    output
+  def output
+    call if @output.nil?
+    @output
   end
 
   def halted?
@@ -117,7 +117,7 @@ class ActiveOperation::Base
     raise ActiveOperation::AlreadyCompletedError if completed?
 
     self.state = :halted
-    self.output = args.length > 1 ? args : args.first
+    @output = args.length > 1 ? args : args.first
     throw :interrupt
   end
 
@@ -125,7 +125,7 @@ class ActiveOperation::Base
     raise ActiveOperation::AlreadyCompletedError if completed?
 
     self.state = :succeeded
-    self.output = args.length > 1 ? args : args.first
+    @output = args.length > 1 ? args : args.first
     throw :interrupt
   end
 end

--- a/spec/active_operation/base_spec.rb
+++ b/spec/active_operation/base_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe ActiveOperation::Base do
+  subject(:operation) do
+    Class.new(ActiveOperation::Base) do
+      def execute
+        Random.rand
+      end
+    end
+  end
+
+  specify ".call should return the operation instance" do
+    expect(operation.call).to be_kind_of(operation)
+  end
+
+  specify ".call should invoke the operation" do
+    operation_instance = operation.call
+    expect(operation_instance).to be_succeeded
+  end
+
+  specify ".call should generate and memoize an output" do
+    operation_instance = operation.call
+    expect(operation_instance.output).to eq(operation_instance.output)
+  end
+
+  specify ".output should return the operation output" do
+    expect(operation.output).to be_kind_of(Float)
+  end
+
+  specify "#call should return self" do
+    operation_instance = operation.new
+    expect(operation_instance.call).to eq(operation_instance)
+  end
+
+  specify "#output should run the operation" do
+    operation_instance = operation.new
+    expect { operation_instance.output }.to change { operation_instance.state }.from(:initialized).to(:succeeded)
+  end
+
+  specify "#output should return the output" do
+    expect(operation.output).to be_kind_of(Float)
+  end
+
+  specify "#output should memoize the result" do
+    operation_instance = operation.new
+    expect(operation_instance.output).to eq(operation_instance.output)
+  end
+end

--- a/spec/active_operation/callbacks_spec.rb
+++ b/spec/active_operation/callbacks_spec.rb
@@ -79,7 +79,7 @@ describe ActiveOperation::Base do
     end
 
     it "should appear in the expected order when the operation is executed" do
-      log = operation.perform
+      log = operation.output
       expect(log).to eq(%i[
         before
         around_before
@@ -89,86 +89,86 @@ describe ActiveOperation::Base do
       ])
     end
 
-    it "should run after callbacks independent of operation outcome" do
-      operation_instance = operation.run(halt_in: :before)
+    it "should call after callbacks independent of operation outcome" do
+      operation_instance = operation.call(halt_in: :before)
       expect(operation_instance.log).to eq(%i[
         after
       ])
     end
 
     it "should support halting in before statements" do
-      expect(operation.perform(halt_in: :before)).to eq(:before)
+      expect(operation.output(halt_in: :before)).to eq(:before)
     end
 
     it "should support halting in before statements" do
-      expect(operation.perform(halt_in: :before)).to eq(:before)
+      expect(operation.output(halt_in: :before)).to eq(:before)
     end
 
     it "should support halting in around statements before #execute is called" do
-      expect(operation.perform(halt_in: :around)).to eq(:around)
+      expect(operation.output(halt_in: :around)).to eq(:around)
     end
 
     it "should support succeeding in before statements" do
-      expect(operation.perform(succeed_in: :before)).to eq(:before)
+      expect(operation.output(succeed_in: :before)).to eq(:before)
     end
 
     it "should support succeeding in around statements" do
-      expect(operation.perform(succeed_in: :around)).to eq(:around)
+      expect(operation.output(succeed_in: :around)).to eq(:around)
     end
 
     it "should raise an error when halting in around statements after #execute has been called" do
-      expect { operation.perform(halt_in: :around_after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
+      expect { operation.output(halt_in: :around_after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
     end
 
     it "should raise an error when succeeding in around statements after #execute has been called" do
-      expect { operation.perform(succeed_in: :around_after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
+      expect { operation.output(succeed_in: :around_after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
     end
 
     it "should raise an error when halting in after statements" do
-      expect { operation.perform(halt_in: :after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
+      expect { operation.output(halt_in: :after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
     end
 
     it "should raise an error when succeeding in after statements" do
-      expect { operation.perform(succeed_in: :after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
+      expect { operation.output(succeed_in: :after) }.to raise_error(ActiveOperation::AlreadyCompletedError)
     end
 
-    it "should run error callbacks after an exception in a before statement" do
-      expect { operation.run(raise_in: :before, error_monitor: error_monitor) }.to raise_error(RuntimeError, "before")
+    it "should call error callbacks after an exception in a before statement" do
+      expect { operation.call(raise_in: :before, error_monitor: error_monitor) }.to raise_error(RuntimeError, "before")
       expect(error_monitor).to have_received(:log).with(an_instance_of(RuntimeError))
     end
 
-    it "should run error callbacks after an exception in a after statement" do
-      expect { operation.run(raise_in: :after, error_monitor: error_monitor) }.to raise_error(RuntimeError, "after")
+    it "should call error callbacks after an exception in a after statement" do
+      expect { operation.call(raise_in: :after, error_monitor: error_monitor) }.to raise_error(RuntimeError, "after")
       expect(error_monitor).to have_received(:log).with(an_instance_of(RuntimeError))
     end
 
-    it "should run error callbacks after an exception in a around statement before #execute has been called" do
-      expect { operation.run(raise_in: :around, error_monitor: error_monitor) }. to raise_error(RuntimeError, "around")
+    it "should call error callbacks after an exception in a around statement before #execute has been called" do
+      expect { operation.call(raise_in: :around, error_monitor: error_monitor) }. to raise_error(RuntimeError, "around")
       expect(error_monitor).to have_received(:log).with(an_instance_of(RuntimeError))
     end
 
-    it "should run error callbacks after an exception in a around statement after #execute has been called" do
-      expect { operation.run(raise_in: :around_after, error_monitor: error_monitor) }.to raise_error(RuntimeError, "around_after")
+    it "should call error callbacks after an exception in a around statement after #execute has been called" do
+      expect { operation.call(raise_in: :around_after, error_monitor: error_monitor) }.to raise_error(RuntimeError, "around_after")
       expect(error_monitor).to have_received(:log).with(an_instance_of(RuntimeError))
     end
 
-    it "should not run error callbacks if operation halted" do
-      expect(operation.run(halt_in: :before, error_monitor: error_monitor)).to be_halted
+    it "should not call error callbacks if operation halted" do
+      expect(operation.call(halt_in: :before, error_monitor: error_monitor)).to be_halted
       expect(error_monitor).to_not have_received(:log)
     end
 
-    it "should not run error callbacks if operation succeeded" do
-      expect(operation.run(succeed_in: :before, error_monitor: error_monitor)).to be_succeeded
+    it "should not call error callbacks if operation succeeded" do
+      expect(operation.call(succeed_in: :before, error_monitor: error_monitor)).to be_succeeded
       expect(error_monitor).to_not have_received(:log)
     end
 
-    it "should run succeeded callbacks after when the operation succeeded" do
-      expect(operation.run(succeed_in: :before, succeeded_monitor: succeeded_monitor)).to be_succeeded
+    it "should call succeeded callbacks after when the operation succeeded" do
+      expect(operation.call(succeed_in: :before, succeeded_monitor: succeeded_monitor)).to be_succeeded
       expect(succeeded_monitor).to have_received(:log).with(:succeeded)
     end
 
-    it "should run halted callbacks after when the operation halted" do
-      expect(operation.run(halt_in: :before, halted_monitor: halted_monitor)).to be_halted
+    it "should call halted callbacks after when the operation halted" do
+      expect(operation.call(halt_in: :before, halted_monitor: halted_monitor)).to be_halted
       expect(halted_monitor).to have_received(:log).with(:halted)
     end
   end

--- a/spec/active_operation/control_flow_spec.rb
+++ b/spec/active_operation/control_flow_spec.rb
@@ -17,25 +17,25 @@ describe ActiveOperation::Base do
       end
     end
 
-    it "should run #when_succeeded callbacks if the operation succeeded" do
-      operation_instance = operation.run(desired_outcome: :succeeded)
+    it "should call #when_succeeded callbacks if the operation succeeded" do
+      operation_instance = operation.call(desired_outcome: :succeeded)
       expect { operation_instance.when_succeeded { throw :succeeded } }.to throw_symbol(:succeeded)
     end
 
     it "should invoke #when_succeeded callbacks with the output" do
-      operation_instance = operation.run(desired_outcome: :succeeded)
+      operation_instance = operation.call(desired_outcome: :succeeded)
       operation_instance.when_succeeded do |output|
         expect(output).to be(:succeeded)
       end
     end
 
-    it "should run #when_halted callbacks if the operation halted" do
-      operation_instance = operation.run(desired_outcome: :halted)
+    it "should call #when_halted callbacks if the operation halted" do
+      operation_instance = operation.call(desired_outcome: :halted)
       expect { operation_instance.when_halted { throw :halted } }.to throw_symbol(:halted)
     end
 
     it "should invoke #when_halted callbacks with the output" do
-      operation_instance = operation.run(desired_outcome: :halted)
+      operation_instance = operation.call(desired_outcome: :halted)
       operation_instance.when_halted do |output|
         expect(output).to be(:halted)
       end


### PR DESCRIPTION
- `ActiveOperation.output` instantiates, executes the operation and returns its output
- `ActiveOperation.call` instantiates, executes the operation and returns the operation instance
- `ActiveOperation#output` executes the operation if necessary and returns the output
- `ActiveOperation#call` executes the operation and returns itself
