### PR TITLE
Support for positional arguments

### DIFF
--- a/lib/active_operation.rb
+++ b/lib/active_operation.rb
@@ -18,4 +18,5 @@ module ActiveOperation
 end
 
 require "active_operation/version"
+require "active_operation/input"
 require "active_operation/base"

--- a/lib/active_operation/input.rb
+++ b/lib/active_operation/input.rb
@@ -1,0 +1,18 @@
+class ActiveOperation::Input
+  include SmartProperties
+
+  property :type, accepts: [:positional, :keyword], required: true
+  property :property, accepts: SmartProperties::Property, required: true
+
+  def positional?
+    type == :positional
+  end
+
+  def keyword?
+    type == :keyword
+  end
+
+  def name
+    property.name
+  end
+end

--- a/spec/active_operation/input_spec.rb
+++ b/spec/active_operation/input_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe ActiveOperation::Base do
+  context "input handling" do
+    subject(:operation) do
+      Class.new(ActiveOperation::Base) do
+        input :name
+        input :subscribe_to_newsletter, type: :keyword
+
+        def execute
+          [name, subscribe_to_newsletter]
+        end
+      end
+    end
+
+    specify "the operation should require a name" do
+      expect { operation.new }.to raise_error(ArgumentError)
+    end
+
+    specify "the operation should take the name as a positional argument" do
+      operation_instance = operation.new("John")
+      expect(operation_instance.name).to eq("John")
+    end
+  end
+end


### PR DESCRIPTION
Operations can now be initialized with positional arguments and keyword arguments. The `.input` method defines a positional argument by default. Supplying `:keyword` as the type changes the argument to be a keyword argument.
