### PR TITLE
Callback objects

### DIFF
--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -9,9 +9,9 @@ class ActiveOperation::Base
   protected :state=
 
   define_callbacks :execute
-  define_callbacks :error
-  define_callbacks :succeeded
-  define_callbacks :halted
+  define_callbacks :error, scope: [:name]
+  define_callbacks :succeeded, scope: [:name]
+  define_callbacks :halted, scope: [:name]
 
   class << self
     def call(*args)


### PR DESCRIPTION
ActiveSupport::Callbacks supports three different ways to configure a callback: pass a block, implement a method, pass an object implementing methods that correspond to the callback names. This commit adds support for the latter.
