### PR TITLE
Default terminator

### DIFF
--- a/lib/active_operation.rb
+++ b/lib/active_operation.rb
@@ -4,17 +4,6 @@ require "smart_properties"
 module ActiveOperation
   class Error < RuntimeError; end
   class AlreadyCompletedError < Error; end
-
-  def self.terminator
-    ->(target, result_lambda) {
-      terminate = true
-      catch(:interrupt) do
-        result_lambda.call
-        terminate = false
-      end
-      terminate
-    }
-  end
 end
 
 require "active_operation/version"

--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -8,7 +8,7 @@ class ActiveOperation::Base
   property :state, accepts: [:initialized, :halted, :succeeded, :failed], required: true, default: :initialized
   protected :state=
 
-  define_callbacks :execute, terminator: ActiveOperation.terminator
+  define_callbacks :execute
   define_callbacks :error
   define_callbacks :succeeded
   define_callbacks :halted
@@ -81,7 +81,7 @@ class ActiveOperation::Base
   end
 
   around do |operation, callback|
-    catch(:interrupt) do
+    catch(:abort) do
       callback.call
     end
   end
@@ -100,7 +100,7 @@ class ActiveOperation::Base
 
   def call
     run_callbacks :execute do
-      catch(:interrupt) do
+      catch(:abort) do
         next if completed?
         @output = execute
         self.state = :succeeded
@@ -154,7 +154,7 @@ class ActiveOperation::Base
 
     self.state = :halted
     @output = args.length > 1 ? args : args.first
-    throw :interrupt
+    throw :abort
   end
 
   def succeed(*args)
@@ -162,6 +162,6 @@ class ActiveOperation::Base
 
     self.state = :succeeded
     @output = args.length > 1 ? args : args.first
-    throw :interrupt
+    throw :abort
   end
 end


### PR DESCRIPTION
Removes `ActiveOperation.terminator` in favour of `ActiveSupport::Callbacks.default_terminator` by replacing the symbol that currently thrown with `:abort`.
