### PR TITLE
Simplify ActiveOperation Execution API

### DIFF
--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -18,10 +18,6 @@ class ActiveOperation::Base
       new(*args).call
     end
 
-    def output(*args)
-      new(*args).output
-    end
-
     def inputs
       []
     end
@@ -110,7 +106,7 @@ class ActiveOperation::Base
     run_callbacks :halted if halted?
     run_callbacks :succeeded if succeeded?
 
-    self
+    self.output
   rescue => error
     self.state = :failed
     self.error = error
@@ -119,7 +115,7 @@ class ActiveOperation::Base
   end
 
   def output
-    call if @output.nil?
+    call unless self.completed?
     @output
   end
 

--- a/spec/active_operation/base_spec.rb
+++ b/spec/active_operation/base_spec.rb
@@ -9,27 +9,13 @@ describe ActiveOperation::Base do
     end
   end
 
-  specify ".call should return the operation instance" do
-    expect(operation.call).to be_kind_of(operation)
+  specify ".call should return the operation output" do
+    expect(operation.call).to be_kind_of(Float)
   end
 
-  specify ".call should invoke the operation" do
-    operation_instance = operation.call
-    expect(operation_instance).to be_succeeded
-  end
-
-  specify ".call should generate and memoize an output" do
-    operation_instance = operation.call
-    expect(operation_instance.output).to eq(operation_instance.output)
-  end
-
-  specify ".output should return the operation output" do
-    expect(operation.output).to be_kind_of(Float)
-  end
-
-  specify "#call should return self" do
+  specify "#call should return the operation output" do
     operation_instance = operation.new
-    expect(operation_instance.call).to eq(operation_instance)
+    expect(operation_instance.call).to be_kind_of(Float)
   end
 
   specify "#output should run the operation" do
@@ -38,7 +24,8 @@ describe ActiveOperation::Base do
   end
 
   specify "#output should return the output" do
-    expect(operation.output).to be_kind_of(Float)
+    operation_instance = operation.new
+    expect(operation_instance.output).to be_kind_of(Float)
   end
 
   specify "#output should memoize the result" do


### PR DESCRIPTION
- Changes `.call` to return the operation output
- Removes `.output`
