### PR TITLE
ActiveOperation::Base call alias

### DIFF
--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -19,7 +19,10 @@ class ActiveOperation::Base
     def perform(*args)
       new(*args).call
     end
-    alias call perform
+
+    def call(*args)
+      perform(*args)
+    end
 
     def inputs
       []
@@ -120,7 +123,10 @@ class ActiveOperation::Base
     run_callbacks :error
     raise
   end
-  alias call perform
+
+  def call
+    perform
+  end
 
   def output
     call unless self.completed?

--- a/spec/active_operation/base_spec.rb
+++ b/spec/active_operation/base_spec.rb
@@ -32,4 +32,24 @@ describe ActiveOperation::Base do
     operation_instance = operation.new
     expect(operation_instance.output).to eq(operation_instance.output)
   end
+
+  context "when overriding perform" do
+    subject(:operation) do
+      Class.new(described_class) do
+        def perform
+          "overwritten"
+        end
+      end
+    end
+
+    specify "the #call alias should be resolved at runtime not at boot time" do
+      expect(operation.new.perform).to eq("overwritten")
+      expect(operation.new.call).to eq("overwritten")
+    end
+
+    specify "the .call alias should be resolved at runtime not at boot time" do
+      expect(operation.perform).to eq("overwritten")
+      expect(operation.call).to eq("overwritten")
+    end
+  end
 end


### PR DESCRIPTION
Previously overriding #perform would have caused #call to reference the old implementation. This PR ensures that #call invokes the correct #perform method.