### PR TITLE
Require core ext for Hash#slice from ActiveSupport

### DIFF
--- a/lib/active_operation.rb
+++ b/lib/active_operation.rb
@@ -1,4 +1,6 @@
+require "active_support/dependencies/autoload"
 require "active_support/callbacks"
+require "active_support/core_ext"
 require "delegate"
 require "smart_properties"
 


### PR DESCRIPTION
This adds the require to load the `core_ext` from ActiveSupport. The gem uses `Hash#slice` and that's part of that dependency:

https://api.rubyonrails.org/classes/Hash.html#method-i-slice

As of Ruby 2.5 this isn't necessary, but CI runs with 2.3.1.

Also needed to pull in Autoload since the core ext depends on it.