### PR TITLE
Rewrite generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The core idea behind an operation is to move code that usually would either live
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'active_operation', '~> 0.1.0'
+gem 'active_operation'
 ```
 
 And then execute:
@@ -20,7 +20,7 @@ And then execute:
 $ bundle
 ```
 
-Or install it yourself as:
+Or install it manually as:
 
 ```
 $ gem install active_operation
@@ -28,16 +28,16 @@ $ gem install active_operation
 
 ### Rails
 
-We recommend running the install generator to initialize a base operation:
+Run the the install generator to initialize a base operation:
 
 ```
 rails g active_operation:install
 ```
 
-You can also generate new operations using:
+Then generate the desired operation:
 
 ```
-rails g active_operation:operation Signup
+rails g active_operation:operation signup/create_user
 ```
 
 ## Usage

--- a/lib/active_operation.rb
+++ b/lib/active_operation.rb
@@ -1,4 +1,6 @@
+require "active_support/dependencies/autoload"
 require "active_support/callbacks"
+require "active_support/core_ext"
 require "delegate"
 require "smart_properties"
 

--- a/lib/active_operation/matcher/execution.rb
+++ b/lib/active_operation/matcher/execution.rb
@@ -161,6 +161,8 @@ module ActiveOperation
   end
 end
 
+require 'rspec/core' unless defined? RSpec.configure
+
 RSpec.configure do |config|
   config.include ActiveOperation::Matcher::Execution
 end

--- a/lib/generators/active_operation/install/install_generator.rb
+++ b/lib/generators/active_operation/install/install_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/generators/base'
 require 'rails/generators/active_record'
 
@@ -7,7 +8,7 @@ module ActiveOperation
       source_root File.expand_path('../../../../../support/templates', __FILE__)
 
       def create_application_operation
-        template 'application_operation.rb', 'app/operations/application_operation.rb'
+        template 'application_operation.rb.erb', 'app/operations/application_operation.rb'
       end
     end
   end

--- a/lib/generators/active_operation/operation/operation_generator.rb
+++ b/lib/generators/active_operation/operation/operation_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/generators/base'
 require 'rails/generators/active_record'
 
@@ -6,8 +7,10 @@ module ActiveOperation
     class OperationGenerator < Rails::Generators::NamedBase
       source_root File.expand_path('../../../../../support/templates', __FILE__)
 
+      hook_for :test_framework
+
       def create_operation
-        template 'operation.rb', File.join('app/operations', class_path, "#{file_name}.rb")
+        template 'operation.rb.erb', File.join('app/operations', class_path, "#{file_name}_operation.rb")
       end
     end
   end

--- a/lib/generators/rspec/operation/operation_generator.rb
+++ b/lib/generators/rspec/operation/operation_generator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Rspec
+  module Generators
+    class OperationGenerator < Rails::Generators::NamedBase
+      source_root File.expand_path('../../../../../support/templates', __FILE__)
+
+      def copy_files
+        template 'operation_spec.rb.erb', File.join('spec/operations', class_path, "#{file_name}_operation_spec.rb")
+      end
+    end
+  end
+end

--- a/lib/generators/test_unit/operation/operation_generator.rb
+++ b/lib/generators/test_unit/operation/operation_generator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module TestUnit
+  module Generators
+    class OperationGenerator < Rails::Generators::NamedBase
+      source_root File.expand_path('../../../../../support/templates', __FILE__)
+
+      def copy_files
+        template 'operation_test.rb.erb', File.join('test/operations', class_path, "#{file_name}_operation_test.rb")
+      end
+    end
+  end
+end

--- a/support/templates/application_operation.rb.erb
+++ b/support/templates/application_operation.rb.erb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class ApplicationOperation < ActiveOperation::Base
 end

--- a/support/templates/operation.rb.erb
+++ b/support/templates/operation.rb.erb
@@ -1,4 +1,5 @@
-class <%= name %> < ApplicationOperation
+# frozen_string_literal: true
+class <%= class_name %>Operation < ApplicationOperation
   # input :email, accepts: String, type: :keyword, required: true
   # input :password, accepts: String, type: :keyword, required: true
   #

--- a/support/templates/operation_spec.rb.erb
+++ b/support/templates/operation_spec.rb.erb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe <%= class_name %>Operation, type: :operation do
+  describe "#execute" do
+    it "should be tested"
+  end
+end

--- a/support/templates/operation_test.rb.erb
+++ b/support/templates/operation_test.rb.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+<% module_namespacing do -%>
+class <%= class_name %>OperationTest < ActiveSupport::TestCase
+  # test "#execute" do
+  #   # TODO
+  # end
+end
+<% end -%>


### PR DESCRIPTION
This rewrites the rails generators for this gem. Including:

* Add the frozen magic constant to generated files.
* Add the support for `:test_framework` hook.
* Add RSpec template.
* Add TestUnit (Minitest) template.
* Use the `.rb.erb` suffix.
* Handle class names correctly.
* Handle nesting correctly.
* Add the -operation suffix.

Tested on both minitest:

```
$ bin/rails g active_operation:operation fruit/cherry
      invoke  test_unit
      create    test/operations/fruit/cherry_operation_test.rb
      create  app/operations/fruit/cherry_operation.rb
$ bin/rake test
Run options: --seed 3904

# Running:

Finished in 0.005424s, 184.3658 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

And rspec:

```
$ bin/rails g active_operation:operation fruit/blueberry
      invoke  rspec
      create    spec/operations/fruit/blueberry_operation_spec.rb
      create  app/operations/fruit/blueberry_operation.rb
$ bundle exec rspec
*

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Fruit::BlueberryOperation#execute should be tested
     # Not yet implemented
     # ./spec/operations/fruit/blueberry_operation_spec.rb:6


Finished in 0.00091 seconds (files took 3.71 seconds to load)
1 example, 0 failures, 1 pending
```