### PR TITLE
Fix typo in operation generator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rails g active_operation:install
 Then generate the desired operation:
 
 ```
-rails g active_operation:operation signup/create_user
+rails g active_operation:operation Signup::CreateUser
 ```
 
 ## Usage


### PR DESCRIPTION
`rails g active_operation:operation signup/create_user` will create a file like

```rb
# app/operations/signup/create_user.rb
class signup/create_user < ApplicationOperation
```

Using the class name instead generates the expected code:

```rb
# app/operations/signup/create_user.rb
class Signup::CreateUser < ApplicationOperation
```