### PR TITLE
Fix ruby2_keywords on Ruby 3.2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: [2.6.9, 2.7.5, 3.0.3]
+        ruby_version: ["2.6", "2.7", "3.0", "3.1", "3.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.1
-before_install: gem install bundler -v 1.12.5

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+rspec = RSpec::Core::RakeTask.new(:spec)
+rspec.ruby_opts = "-w"
 
 task :default => :spec

--- a/lib/active_operation/base.rb
+++ b/lib/active_operation/base.rb
@@ -4,7 +4,7 @@ class ActiveOperation::Base
   include SmartProperties
   include ActiveSupport::Callbacks
 
-  attr_accessor :output
+  attr_writer :output
   attr_accessor :error
 
   property :state, accepts: [:initialized, :halted, :succeeded, :failed], required: true, default: :initialized
@@ -19,6 +19,7 @@ class ActiveOperation::Base
     def perform(*args)
       new(*args).call
     end
+    ruby2_keywords :perform if respond_to?(:ruby2_keywords, true)
 
     def from_proc(execute)
       Class.new(self) do
@@ -54,15 +55,18 @@ class ActiveOperation::Base
     def call(*args)
       perform(*args)
     end
+    ruby2_keywords :call if respond_to?(:ruby2_keywords, true)
 
     def inputs
       []
     end
 
     def to_proc
-      ->(*args) {
+      proc = ->(*args) {
         perform(*args)
       }
+      proc.ruby2_keywords if proc.respond_to?(:ruby2_keywords)
+      proc
     end
 
     protected

--- a/lib/active_operation/pipeline.rb
+++ b/lib/active_operation/pipeline.rb
@@ -17,7 +17,7 @@ module ActiveOperation
           result[key] = value.kind_of?(Proc) ? context.instance_exec(&value) : value
         end
 
-        __getobj__.new *positional_args, attributes_from_input.merge(attributes_from_pipeline)
+        __getobj__.new(*positional_args, attributes_from_input.merge(attributes_from_pipeline))
       end
     end
 

--- a/spec/active_operation/pipeline_spec.rb
+++ b/spec/active_operation/pipeline_spec.rb
@@ -211,7 +211,7 @@ describe ActiveOperation::Pipeline do
       pipeline = described_class.compose do
         use -> { 2 }
         use -> (number) { number * 2 }
-        use -> (number) { number -1 }
+        use -> (number) { number - 1 }
       end
 
       expect(pipeline).to succeed_to_perform.and_return(3)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+if Warning.respond_to?(:[])
+  Warning[:deprecated] = true
+end
+
 require 'pry'
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'active_operation'


### PR DESCRIPTION
The first versions of ruby that introduced ruby2_keywords had a small bug, only the first method in a chain of call needed to mark itself as using ruby2_keywords smeantic, e.g.

```ruby
def foo(a:); end

def bar(*args)
  foo(*args)
end

def baz(*args)
  bar(*args)
end
ruby2_keywords :baz

baz(a: 1)
```

Up to 3.1 the above cause no issue,
however in 3.2, `bar` also need to be marked with `ruby2_keywords`.